### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/dangarbri/pico-distance-sensor
 [submodule "picopad-sdk/picopad-base/src/vendor/hagl_hal"]
 	path = picopad-sdk/picopad-base/src/vendor/hagl_hal
-	url = git@github.com:tuupola/hagl_pico_mipi.git
+	url = https://github.com/tuupola/hagl_pico_mipi.git
 [submodule "picopad-sdk/picopad-base/src/vendor/hagl"]
 	path = picopad-sdk/picopad-base/src/vendor/hagl
-	url = git@github.com:tuupola/hagl.git
+	url = https://github.com/tuupola/hagl.git


### PR DESCRIPTION
changed for the submodules hagl and hagl_hal the git urls to https that users with out git ssh access can do a 
 git clone --recurse-submodules https://github.com/tvecera/picopad-playground

without getting the error:
https://docs.github.com/en/authentication/troubleshooting-ssh/error-permission-denied-publickey